### PR TITLE
Tin-silver Alloy ingot recipe

### DIFF
--- a/kubejs/server_scripts/recipes/materials/gt.js
+++ b/kubejs/server_scripts/recipes/materials/gt.js
@@ -50,5 +50,8 @@ ServerEvents.recipes(event => {
 
     // refined_fluxed_electrum
 
+    // Smelting and blasting recipes for tin-silver alloy ingots
+    event.recipes.smelting('gtceu:tin_silver_alloy_ingot', 'gtceu:tin_silver_alloy_dust');
+    event.recipes.blasting('gtceu:tin_silver_alloy_ingot', 'gtceu:tin_silver_alloy_dust');
 
 });


### PR DESCRIPTION
## Problem
The tin-silver alloy ingot did not have a recipe dedicated recipe from Tin-Silver Alloy dust, instead you had to alloysmelter it into a block and then into and ingot
## Solution
Adds both a minecraft furnace and minecraft blast furnace recipe using the Dust form. As GT furnace also inherits this recipe.