### PR TITLE
Quick Changes to the Source Cells

### DIFF
--- a/config/twilightforest-common.toml
+++ b/config/twilightforest-common.toml
@@ -70,7 +70,7 @@ cloudBlockPrecipitationDistance = 32
 	enableShapelessCrafting = false
 	#Disables the uncrafting function of the uncrafting table. Recommended as a last resort if there's too many things to change about its behavior (or you're just lazy, I dont judge).
 	#Do note that special uncrafting recipes are not disabled as the mod relies on them for other things.
-	disableUncrafting = false
+	disableUncrafting = true
 	#Disables any usage of the uncrafting table, as well as prevents it from showing up in loot or crafted.
 	#Please note that table has more uses than just uncrafting, you can read about them here! http://benimatic.com/tfwiki/index.php?title=Uncrafting_Table
 	#It is highly recommended to keep the table enabled as the mod has special uncrafting exclusive recipes, but the option remains for people that dont want the table to be functional at all.

--- a/kubejs/server_scripts/recipes/gregify/ars/ars.js
+++ b/kubejs/server_scripts/recipes/gregify/ars/ars.js
@@ -25,6 +25,8 @@ ServerEvents.recipes(event => {
     event.remove({ id: 'ars_nouveau:novice_spell_book' }) // tdl upgrades
     event.remove({ id: 'ars_nouveau:scribes_table' })
 
+    event.replaceInput( {input: 'ars_nouveau:source_gem'},'ars_nouveau:source_gem','#forge:gems/source') //stops recipes from breaking, can be changed back if needed
+
     event.recipes.gtceu.extractor('kubejs:magebloom_oil')
         .itemInputs(
             '1x ars_nouveau:magebloom',

--- a/kubejs/server_scripts/recipes/gregify/ars/arseng.js
+++ b/kubejs/server_scripts/recipes/gregify/ars/arseng.js
@@ -1,0 +1,46 @@
+ServerEvents.recipes(event =>{
+	event.remove({output: 'arseng:source_cell_housing'})
+
+	event.recipes.ars_nouveau.enchanting_apparatus(
+		['gtceu:source_plate', 'gtceu:source_plate', 'gtceu:rose_gold_plate', 'gtceu:rose_gold_plate',
+			'gtceu:rose_gold_plate', 'gtceu:rose_gold_plate', 'ars_nouveau:manipulation_essence', 'ars_nouveau:manipulation_essence'
+		], // input items
+		'ae2:item_cell_housing', // reagent
+		'arseng:source_cell_housing', // output
+		1000, // source cost
+		true // keep nbt of reagent, think like a smithing recipe
+	)
+
+	event.remove({input: 'arseng:source_cell_housing', mod:'arseng'})
+
+
+	event.recipes.gtceu.canner('kubejs:1k_source_cell')  
+		.itemInputs('ae2:cell_component_1k', 'arseng:source_cell_housing')
+		.itemOutputs('1x arseng:source_storage_cell_1k')
+		.duration(100)
+		.EUt(120)
+
+	event.recipes.gtceu.canner('kubejs:4k_source_cell')  
+		.itemInputs('ae2:cell_component_4k', 'arseng:source_cell_housing')
+		.itemOutputs('1x arseng:source_storage_cell_4k')
+		.duration(100)
+		.EUt(120)
+
+	event.recipes.gtceu.canner('kubejs:16k_source_cell')  
+		.itemInputs('ae2:cell_component_16k', 'arseng:source_cell_housing')
+		.itemOutputs('1x arseng:source_storage_cell_16k')
+		.duration(100)
+		.EUt(120)
+
+	event.recipes.gtceu.canner('kubejs:64k_source_cell')  
+		.itemInputs('ae2:cell_component_64k', 'arseng:source_cell_housing')
+		.itemOutputs('1x arseng:source_storage_cell_64k')
+		.duration(100)
+		.EUt(120)
+
+	event.recipes.gtceu.canner('kubejs:256k_source_cell')  
+		.itemInputs('ae2:cell_component_256k', 'arseng:source_cell_housing')
+		.itemOutputs('1x arseng:source_storage_cell_256k')
+		.duration(100)
+		.EUt(120)
+})


### PR DESCRIPTION
+ Source cell housing now uses rose gold and source plates instead of gold and source gems, and now requires source to craft.
+ New canning recipe for the source cells, uses the same recipe as the normal cells
- Also included disabling the Uncrafting Table, as that was enabled again somehow.